### PR TITLE
feat (scripts/lunch and learn): remember lunch and learn topics

### DIFF
--- a/lib/array_memory.coffee
+++ b/lib/array_memory.coffee
@@ -1,0 +1,35 @@
+{EOL} = require('os')
+_ = require('lodash')
+
+class ArrayMemory
+  constructor: (@brain, @key) ->
+
+  remember: (idea) ->
+    memory = @ideas()
+
+    memory.push idea
+
+    @brain.set @key, memory
+
+  forget: (number) ->
+    memory = @ideas()
+
+    _.pullAt(memory, number-1)
+
+    @brain.set @key, memory
+
+  clear: ->
+    @brain.set @key, []
+
+  ideas: ->
+    @brain.get('lunchnlearn') || []
+
+  any: ->
+    _.any(@ideas())
+
+  toString: (joinWith = EOL)->
+    @ideas()
+      .map( (idea, index) -> "#{index+1}: #{idea}" )
+      .join(joinWith)
+
+module.exports = ArrayMemory

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "hubot-scripts": "^2.16.1",
     "hubot-shipit": "^0.2.0",
     "hubot-slack": "^3.3.0",
-    "hubot-sonos": "^1.0.1"
+    "hubot-sonos": "^1.0.1",
+    "lodash": "^3.10.1"
   },
   "engines": {
     "node": "0.10.x"

--- a/scripts/lunchnlearn.coffee
+++ b/scripts/lunchnlearn.coffee
@@ -1,0 +1,46 @@
+# Description:
+#   Control your sonos device from hubot
+#
+# Commands:
+#  hubot lunchnlearn remember <topic> - Remember a n lunch and learn entry.
+#  hubot lunchnlearn topics - Find out what lunch and learn topics are remembered.
+#  hubot lunchnlearn forget <number> - Remove a lunch and learn entry.
+#  hubot lunchnlearn clear - Forget all lunch and learn topics.
+#
+# Author:
+#   cromwellryan
+
+{EOL} = require('os')
+ArrayMemory = require('../lib/array_memory')
+
+module.exports = (robot) ->
+  memory = new ArrayMemory(robot.brain, 'lunchnlearn')
+
+  # Remember a lunch n learn topic
+  robot.respond /lunch(?:and|n)learn remember (.*)/i, (res) ->
+    idea = res.match[1]
+    memory.remember(idea)
+    res.emote "Got it! I'll remember _#{idea}_ until you tell me to `forget` it."
+
+  # Provide a list of ideas for lunch n learn
+  robot.respond /lunch(?:and|n)learn topics/i, (res) ->
+    memory = memory
+
+    if(memory.any())
+      res.emote "Let me think...#{EOL}#{memory}"
+    else
+      res.emote "Sorry, I'm drawing a blank."
+
+  # Remove an item by number
+  robot.respond /lunch(?:and|n)learn forget (\d+)/i, (res) ->
+    numberToRemove = parseInt(res.match[1])
+
+    if(numberToRemove == NaN)
+      new res.emote "Sorry, not sure about that topic. Check help with `help lunchnlearn`."
+    else
+      memory.forget(numberToRemove)
+      res.emote "No worries!  I'll take care of that for you right away"
+
+  robot.respond /lunch(?:and|n)learn clear/i, (res) ->
+    memory.clear()
+    res.emote "Whoa! I'll do it, but that's pretty aggressive."


### PR DESCRIPTION
Commands:

```
hubot lunchnlearn remember <topic> - Remember a n lunch and learn entry.
hubot lunchnlearn topics - Find out what lunch and learn topics are remembered.
hubot lunchnlearn forget <number> - Remove a lunch and learn entry.
hubot lunchnlearn clear - Forget all lunch and learn topics.
```

@bryanbraun @robtarr 

You can test this at the command line via 
`./bin/hubot --adapter slack`

or run Sparkbox locally connected to slack via 
`HUBOT_SLACK_TOKEN=xoxb-8666923238-n52a2PpAQJLEviRSVTPBYV28 ./bin/hubot --adapter slack`

Then run each of the above commands.
