### PR TITLE
feat: enable remember script

### DIFF
--- a/hubot-scripts.json
+++ b/hubot-scripts.json
@@ -1,1 +1,1 @@
-[]
+["remember.coffee"]

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "hubot-scripts": "^2.16.1",
     "hubot-shipit": "^0.2.0",
     "hubot-slack": "^3.3.0",
-    "lodash": "^3.10.1"
+    "lodash": "^3.10.1",
+    "underscore": "^1.8.3"
   },
   "engines": {
     "node": "0.10.x"


### PR DESCRIPTION
Remember script gives sparkbot the ability to remember keywords and data
to match. For example, people forget how to use the VPN.